### PR TITLE
Move player selection data to new GameDataController

### DIFF
--- a/Board Game Editor/Assets/Resources/Scenes/MainMenu.unity
+++ b/Board Game Editor/Assets/Resources/Scenes/MainMenu.unity
@@ -739,15 +739,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1e3830089bbd5bc43ad082433ef822c7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  saveCtrl: {fileID: 0}
+  gameData: {fileID: 0}
   textPlayerCount: {fileID: 285747124}
-  playerCount: 0
+  playerCount: 4
+  playerCountSelect: {fileID: 894674163}
   pieceSelectors:
   - {fileID: 997339930}
   - {fileID: 1508378418}
   - {fileID: 1108349970}
   - {fileID: 630829541}
   activePieceSelectors: []
-  playerCountSelect: {fileID: 0}
   pieceColors:
   - {fileID: 2100000, guid: d39af9b3ed4f9021c94546aa9e896f99, type: 2}
   - {fileID: 2100000, guid: 0d32f67be6401671588fadfeade4bfa4, type: 2}
@@ -3346,6 +3348,7 @@ GameObject:
   - component: {fileID: 1307122939}
   - component: {fileID: 1307122938}
   - component: {fileID: 1307122937}
+  - component: {fileID: 1307122940}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -3419,6 +3422,39 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1307122940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1307122936}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
 --- !u!1 &1327353506
 GameObject:
   m_ObjectHideFlags: 0

--- a/Board Game Editor/Assets/Resources/Scenes/Persist.unity
+++ b/Board Game Editor/Assets/Resources/Scenes/Persist.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
+  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.12107873, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -123,6 +123,52 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &449685486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 449685487}
+  - component: {fileID: 449685488}
+  m_Layer: 0
+  m_Name: GameDataController
+  m_TagString: GameDataController
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &449685487
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449685486}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 988.7515, y: 534.8811, z: 863.6498}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &449685488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449685486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1defe43f64a39785786e4626991c1fd2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerCount: 4
+  pieceColors: []
 --- !u!1 &1370709625
 GameObject:
   m_ObjectHideFlags: 0
@@ -198,6 +244,8 @@ MonoBehaviour:
   so:
     saveData: []
   currBoardID: 0
+  playerCount: 4
+  pieceColors: []
   ctrl: {fileID: 0}
   gameManager: {fileID: 0}
   sceneCtrl: {fileID: 5216014694576815775}

--- a/Board Game Editor/Assets/Resources/Scripts/GameDataController.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/GameDataController.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+using UnityEngine.SceneManagement;
+using System.Linq;
+
+public class GameDataController : MonoBehaviour
+{
+
+    public int playerCount = 4;
+    public List<Material> pieceColors;
+
+
+    private void Awake()
+    {
+        DontDestroyOnLoad(this.gameObject);
+    }
+
+    void Start()
+    {
+
+    }
+
+    public void SetPlayerCount(int count)
+    {
+        playerCount = count;
+    }
+
+    public void UpdatePieceColors(List<Material> newPieceColors)
+    {
+        pieceColors = newPieceColors;
+    }
+}

--- a/Board Game Editor/Assets/Resources/Scripts/GameDataController.cs.meta
+++ b/Board Game Editor/Assets/Resources/Scripts/GameDataController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1defe43f64a39785786e4626991c1fd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Board Game Editor/Assets/Resources/Scripts/GameManager.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/GameManager.cs
@@ -5,14 +5,15 @@ using UnityEngine;
 public class GameManager : MonoBehaviour
 {
     public SaveController saveCtrl;
+    public GameDataController gameData;
     public int numberOfPlayers;
 
     [SerializeField] bool gameOver = false;
     public int currentTurn = 0;
 
-    [SerializeField]int roll = 0;
+    [SerializeField] int roll = 0;
     public int spacesToMove = 0;
-    [SerializeField]float speed = 1f;
+    [SerializeField] float speed = 1f;
 
     [SerializeField] public List<Player> players = new List<Player>();
 
@@ -29,7 +30,8 @@ public class GameManager : MonoBehaviour
     void Awake()
     {
         saveCtrl = GameObject.FindGameObjectWithTag("SaveController").GetComponent<SaveController>();
-        numberOfPlayers = saveCtrl.playerCount;
+        gameData = GameObject.FindGameObjectWithTag("GameDataController").GetComponent<GameDataController>();
+        numberOfPlayers = gameData.playerCount;
 
         for (int i = 0; i < numberOfPlayers; i++)
         {
@@ -43,7 +45,7 @@ public class GameManager : MonoBehaviour
 
     void Start()
     {
-        Queue<Material> pieceColors = new Queue<Material>(saveCtrl.pieceColors);
+        Queue<Material> pieceColors = new Queue<Material>(gameData.pieceColors);
         foreach (Player plr in players)
         {
             plr.currTile = allTiles[0];
@@ -59,16 +61,20 @@ public class GameManager : MonoBehaviour
     void Update()
     {
         // wait for player to roll dice
-        if(Input.GetMouseButtonDown(0) && !gameOver){
-            spacesToMove = Random.Range(1,7);
+        if (Input.GetMouseButtonDown(0) && !gameOver)
+        {
+            spacesToMove = Random.Range(1, 7);
             roll = spacesToMove;
             var player = players[currentTurn];
-            if(player.escapeRoll == 0 || roll == player.escapeRoll){
+            if (player.escapeRoll == 0 || roll == player.escapeRoll)
+            {
                 player.escapeRoll = 0;
                 StartCoroutine(MovePiece());
-            }else{
+            }
+            else
+            {
                 IncrementTurn();
-            } 
+            }
         }
     }
 
@@ -81,28 +87,37 @@ public class GameManager : MonoBehaviour
 
         var inTransit = false;
         var targetPos = new Vector3();
-        while(spacesToMove != 0){
-            if(inTransit){
+        while (spacesToMove != 0)
+        {
+            if (inTransit)
+            {
                 var step = speed * Time.deltaTime;
                 player.piece.transform.position = Vector3.MoveTowards(player.piece.transform.position, targetPos, step);
-                if(Vector3.Distance(player.piece.transform.position, targetPos) < 0.001f){
+                if (Vector3.Distance(player.piece.transform.position, targetPos) < 0.001f)
+                {
                     inTransit = false;
 
                     spacesToMove -= (int)Mathf.Sign((float)spacesToMove);
-                    if(player.currTile.GetComponent<Tile>().children.Count == 0){
+                    if (player.currTile.GetComponent<Tile>().children.Count == 0)
+                    {
                         spacesToMove = 0;
                         // win game
                         gameOver = true;
                         Debug.Log("Player " + player.ID + " Wins!");
                         break;
                     }
-                    if(!gameOver && spacesToMove == 0)
+                    if (!gameOver && spacesToMove == 0)
                         ApplyEffect();
                 }
-            }else{
-                if(Mathf.Sign(spacesToMove) == 1){
+            }
+            else
+            {
+                if (Mathf.Sign(spacesToMove) == 1)
+                {
                     player.currTile = player.currTile.GetComponent<Tile>().children[0];
-                }else{
+                }
+                else
+                {
                     player.currTile = player.currTile.GetComponent<Tile>().parent;
                 }
                 targetPos = player.currTile.GetComponent<Tile>().GetLocation() + spaceOffsets[player.ID];
@@ -112,11 +127,12 @@ public class GameManager : MonoBehaviour
             yield return null;
         }
         player.piece.GetComponent<GamePiece>().moving = false;
-        if(!gameOver)
+        if (!gameOver)
             IncrementTurn();
     }
 
-    void ApplyEffect(){
+    void ApplyEffect()
+    {
         var player = players[currentTurn];
         player.currTile.GetComponent<Tile>().LandedOn(gameObject.GetComponent<GameManager>());
     }

--- a/Board Game Editor/Assets/Resources/Scripts/SaveController.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/SaveController.cs
@@ -9,8 +9,6 @@ public class SaveController : MonoBehaviour
 {
     public SaveObject so;
     public int currBoardID = 0;
-    public int playerCount = 4;
-    public List<Material> pieceColors;
     public EditorController ctrl;
     public GameManager gameManager;
     public SceneController sceneCtrl;
@@ -226,15 +224,5 @@ public class SaveController : MonoBehaviour
     public GameBoard GetCurrentBoard()
     {
         return so.saveData[currBoardID];
-    }
-
-    public void SetPlayerCount(int count)
-    {
-        playerCount = count;
-    }
-
-    public void UpdatePieceColors(List<Material> newPieceColors)
-    {
-        pieceColors = newPieceColors;
     }
 }

--- a/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
@@ -5,7 +5,6 @@ using UnityEngine.UI;
 
 public class PlayerSelect : MonoBehaviour
 {
-    public SaveController saveCtrl;
     public GameDataController gameData;
 
     public TMPro.TextMeshProUGUI textPlayerCount;
@@ -25,7 +24,6 @@ public class PlayerSelect : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        // saveCtrl = GameObject.FindGameObjectWithTag("SaveController").GetComponent<SaveController>();
         gameData = GameObject.FindGameObjectWithTag("GameDataController").GetComponent<GameDataController>();
         availablePieceColors = new LinkedList<Material>(pieceColors);
         selectedPieceColors = new List<Material> { null, null, null, null };

--- a/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 public class PlayerSelect : MonoBehaviour
 {
     public SaveController saveCtrl;
+    public GameDataController gameData;
 
     public TMPro.TextMeshProUGUI textPlayerCount;
     public int playerCount;
@@ -24,7 +25,8 @@ public class PlayerSelect : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        saveCtrl = GameObject.FindGameObjectWithTag("SaveController").GetComponent<SaveController>();
+        // saveCtrl = GameObject.FindGameObjectWithTag("SaveController").GetComponent<SaveController>();
+        gameData = GameObject.FindGameObjectWithTag("GameDataController").GetComponent<GameDataController>();
         availablePieceColors = new LinkedList<Material>(pieceColors);
         selectedPieceColors = new List<Material> { null, null, null, null };
 
@@ -89,7 +91,7 @@ public class PlayerSelect : MonoBehaviour
             }
         }
 
-        saveCtrl.UpdatePieceColors(selectedPieceColors);
+        gameData.UpdatePieceColors(selectedPieceColors);
     }
 
     public void InitColorToPiece(GameObject piece)
@@ -140,7 +142,7 @@ public class PlayerSelect : MonoBehaviour
         playerCount = value;
         textPlayerCount.text = value.ToString();
         ChangeDisplay((int)value);
-        saveCtrl.SetPlayerCount(value);
+        gameData.SetPlayerCount(value);
     }
 
     public void ChangeColor(GameObject pieceSelector, DIRECTION direction)

--- a/Board Game Editor/ProjectSettings/TagManager.asset
+++ b/Board Game Editor/ProjectSettings/TagManager.asset
@@ -10,6 +10,7 @@ TagManager:
   - End
   - SaveController
   - SceneController
+  - GameDataController
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- removed player selection data (playerCount, pieceColors) and associated methods from SaveController and added to a new GameDataController class
- created new empty game object in Persist scene that contains GameDataController script
- new tag "GameDataController" for retrieving the game object & script
- changed logic in player select script and game manager script to reference GameDataController when setting number of pieces and associated material. 
- removed references to SaveController in the player select script