### PR TITLE
implement Play Game world and player cameras

### DIFF
--- a/Board Game Editor/Assets/Resources/Scenes/PlayGame.unity
+++ b/Board Game Editor/Assets/Resources/Scenes/PlayGame.unity
@@ -216,7 +216,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!114 &175740178
 MonoBehaviour:
@@ -316,14 +316,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 574385219}
-  m_LocalRotation: {x: 0.5591929, y: 0, z: 0, w: 0.8290376}
-  m_LocalPosition: {x: 0, y: 9.69, z: -2}
+  m_LocalRotation: {x: 0.38268343, y: -0, z: -0, w: 0.92387956}
+  m_LocalPosition: {x: -2, y: 2, z: -3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1984737171}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 68, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
 --- !u!114 &574385223
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -370,12 +370,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   saveCtrl: {fileID: 0}
+  gameData: {fileID: 0}
   numberOfPlayers: 2
   gameOver: 0
   currentTurn: 0
   roll: 0
   spacesToMove: 0
   speed: 0.5
+  cameraController: {fileID: 0}
   allTiles: []
   spaceOffsets:
   - {x: 0.25, y: 0, z: 0}
@@ -383,3 +385,244 @@ MonoBehaviour:
   - {x: 0, y: 0, z: 0.25}
   - {x: 0, y: 0, z: -0.25}
   - {x: 0, y: 0, z: 0}
+--- !u!1 &927916638
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 927916639}
+  - component: {fileID: 927916642}
+  - component: {fileID: 927916641}
+  - component: {fileID: 927916640}
+  m_Layer: 0
+  m_Name: Player Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &927916639
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 927916638}
+  m_LocalRotation: {x: 0.2588191, y: 0, z: 0, w: 0.9659258}
+  m_LocalPosition: {x: 0, y: 1.25, z: -1.25}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1600809005}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 30, y: 0, z: 0}
+--- !u!114 &927916640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 927916638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!81 &927916641
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 927916638}
+  m_Enabled: 0
+--- !u!20 &927916642
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 927916638}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!1 &1496437701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1496437703}
+  - component: {fileID: 1496437702}
+  m_Layer: 0
+  m_Name: CameraController
+  m_TagString: CameraController
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1496437702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1496437701}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de5f31bdf0c2b0b488187900fb2cba81, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainCameraRig: {fileID: 1984737171}
+  playerCameraRig: {fileID: 1600809005}
+  followTransform: {fileID: 927916639}
+  cameraTransform: {fileID: 574385222}
+  cameraSpeed: 0.01
+  cameraMovementTime: 5
+  cameraRotationAmount: 0.1
+  cameraPosition: {x: 0, y: 0, z: 0}
+  cameraZoom: {x: 0, y: 0, z: 0}
+  cameraZoomAmount: {x: 0, y: -0.01, z: 0.01}
+  cameraRotation: {x: 0, y: 0, z: 0, w: 0}
+  currentCamera: 0
+  playerTarget: {fileID: 0}
+--- !u!4 &1496437703
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1496437701}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1984737171}
+  - {fileID: 1600809005}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1600809004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1600809005}
+  m_Layer: 0
+  m_Name: Player Camera Rig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1600809005
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1600809004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 927916639}
+  m_Father: {fileID: 1496437703}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1984737170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1984737171}
+  m_Layer: 0
+  m_Name: Main Camera Rig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1984737171
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1984737170}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 574385222}
+  m_Father: {fileID: 1496437703}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Board Game Editor/Assets/Resources/Scripts/CameraController.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/CameraController.cs
@@ -5,27 +5,142 @@ using UnityEngine;
 public class CameraController : MonoBehaviour
 {
     GameObject target;
-    
+    public static CameraController instance;
+    public Transform mainCameraRig;
+    public Transform playerCameraRig;
+    public Transform followTransform;
+    public Transform cameraTransform;
+    public float cameraSpeed;
+    public float cameraMovementTime;
+    public float cameraRotationAmount;
+
+    public Vector3 cameraPosition;
+    public Vector3 cameraZoom;
+    public Vector3 cameraZoomAmount;
+    public Quaternion cameraRotation;
+
+    public enum CAMERA { MAIN, PLAYER };
+    public CAMERA currentCamera;
+    public Transform playerTarget;
+
+
+    void Awake()
+    {
+        instance = this;
+    }
     // Start is called before the first frame update
     void Start()
     {
-        
+        // instance = this;
+
+        currentCamera = CAMERA.MAIN;
+        cameraTransform.gameObject.GetComponent<Camera>().enabled = true;
+        followTransform.gameObject.GetComponent<Camera>().enabled = false;
+
+        cameraPosition = mainCameraRig.position;
+        cameraRotation = mainCameraRig.rotation;
+        cameraZoom = mainCameraRig.localPosition;// cameraTransform.localPosition;  // stay relative to the camera rig
     }
 
     // Update is called once per frame
     void Update()
     {
-        transform.LookAt(target.transform);
 
-        float xDir = Input.GetAxis("Horizontal");
-        float zDir = Input.GetAxis("Vertical");
+        if (currentCamera == CAMERA.MAIN)
+        {
+            ControlKeyboardInput();
+        }
 
-        Vector3 moveDir = new Vector3(xDir, 0.0f, zDir);
-        
-        transform.position += moveDir * 0.01f;
+        if (playerTarget != null)
+        {
+            playerCameraRig.position = Vector3.Lerp(playerCameraRig.position, playerTarget.position, cameraMovementTime * Time.deltaTime);
+        }
+
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            SwitchCameras();
+        }
+
+
+        // transform.LookAt(target.transform);
+
+        // float xDir = Input.GetAxis("Horizontal");
+        // float zDir = Input.GetAxis("Vertical");
+
+        // Vector3 moveDir = new Vector3(xDir, 0.0f, zDir);
+
+        // transform.position += moveDir * 0.01f;
     }
 
-    public void SetTarget(GameObject obj){
+    private void FixedUpdate()
+    {
+
+    }
+    public void SwitchCameras()
+    {
+        if (currentCamera == CAMERA.MAIN)
+        {
+            currentCamera = CAMERA.PLAYER;
+            cameraTransform.gameObject.GetComponent<Camera>().enabled = false;
+            followTransform.gameObject.GetComponent<Camera>().enabled = true;
+        }
+
+        else
+        {
+            currentCamera = CAMERA.MAIN;
+            cameraTransform.gameObject.GetComponent<Camera>().enabled = true;
+            followTransform.gameObject.GetComponent<Camera>().enabled = false;
+        }
+    }
+    public void SetTarget(GameObject obj)
+    {
         target = obj;
+    }
+    void ControlKeyboardInput()
+    {
+
+        if (Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow))
+        {
+            cameraPosition += mainCameraRig.forward * cameraSpeed;
+        }
+
+        else if (Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow))
+        {
+            cameraPosition += mainCameraRig.forward * -cameraSpeed;
+        }
+
+        else if (Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow))
+        {
+            cameraPosition += mainCameraRig.right * -cameraSpeed;
+        }
+
+        else if (Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow))
+        {
+            cameraPosition += mainCameraRig.right * cameraSpeed;
+        }
+
+        else if (Input.GetKey(KeyCode.Q))
+        {
+            cameraRotation *= Quaternion.Euler(Vector3.up * cameraRotationAmount);
+        }
+
+        else if (Input.GetKey(KeyCode.E))
+        {
+            cameraRotation *= Quaternion.Euler(Vector3.up * -cameraRotationAmount);
+        }
+
+        else if (Input.GetKey(KeyCode.R))
+        {
+            cameraZoom += cameraZoomAmount;
+        }
+
+        else if (Input.GetKey(KeyCode.F))
+        {
+            cameraZoom += -cameraZoomAmount;
+        }
+
+        mainCameraRig.position = Vector3.Lerp(mainCameraRig.position, cameraPosition, Time.deltaTime * cameraMovementTime);
+        mainCameraRig.rotation = Quaternion.Lerp(mainCameraRig.rotation, cameraRotation, Time.deltaTime * cameraMovementTime);
+        mainCameraRig.localPosition = Vector3.Lerp(mainCameraRig.localPosition, cameraZoom, Time.deltaTime * cameraMovementTime);
     }
 }

--- a/Board Game Editor/Assets/Resources/Scripts/GameManager.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/GameManager.cs
@@ -55,10 +55,6 @@ public class GameManager : MonoBehaviour
         }
 
         cameraController = GameObject.FindGameObjectWithTag("CameraController").GetComponent<CameraController>();
-        Debug.Log(cameraController);
-        Debug.Log(CameraController.instance);
-
-        Debug.Log(players[currentTurn].piece.transform.position);
         cameraController.playerTarget = players[currentTurn].piece.transform;
     }
 
@@ -143,8 +139,6 @@ public class GameManager : MonoBehaviour
 
     void IncrementTurn()
     {
-        Debug.Log(players[currentTurn].piece.transform.position);
-
         currentTurn += 1;
         if (currentTurn > players.Count - 1)
         {

--- a/Board Game Editor/Assets/Resources/Scripts/GameManager.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/GameManager.cs
@@ -17,7 +17,7 @@ public class GameManager : MonoBehaviour
 
     [SerializeField] public List<Player> players = new List<Player>();
 
-    CameraController cam;
+    public CameraController cameraController;
 
     public List<GameObject> allTiles;
 
@@ -39,8 +39,6 @@ public class GameManager : MonoBehaviour
             players.Add(player);
             player.ID = i;
         }
-        cam = GameObject.Find("Main Camera").GetComponent<CameraController>();
-
     }
 
     void Start()
@@ -55,7 +53,13 @@ public class GameManager : MonoBehaviour
 
             plr.piece.GetComponentInChildren<MeshRenderer>().material = pieceColors.Dequeue();
         }
-        //Debug.Log(players);
+
+        cameraController = GameObject.FindGameObjectWithTag("CameraController").GetComponent<CameraController>();
+        Debug.Log(cameraController);
+        Debug.Log(CameraController.instance);
+
+        Debug.Log(players[currentTurn].piece.transform.position);
+        cameraController.playerTarget = players[currentTurn].piece.transform;
     }
 
     void Update()
@@ -139,6 +143,8 @@ public class GameManager : MonoBehaviour
 
     void IncrementTurn()
     {
+        Debug.Log(players[currentTurn].piece.transform.position);
+
         currentTurn += 1;
         if (currentTurn > players.Count - 1)
         {
@@ -148,6 +154,8 @@ public class GameManager : MonoBehaviour
         {
             IncrementTurn();
         }
-        //cam.SetTarget(players[currentTurn].piece);
+
+        var player = players[currentTurn];
+        cameraController.playerTarget = players[currentTurn].piece.transform;
     }
 }

--- a/Board Game Editor/ProjectSettings/TagManager.asset
+++ b/Board Game Editor/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - SaveController
   - SceneController
   - GameDataController
+  - CameraController
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
implemented the world camera and player camera in the play game scene.

- use space bar to toggle between world and player cameras
- world camera controls:
  - wasd or Up/Down/Left/Right for panning around
  - q or e for rotation
  - f or r for zoom
- player camera locks on to current player and automatically switches to next player on their turn

play game scene:
- parent camera game object - CameraController script component is here
- main camera rig - sets world position of camera
    - contains main camera - sets rotation and offset from rig
- player camera rig - similar
    - contains player camera

files modified:
CameraController: added all the logic for camera controls and switching
GameManager: sets the player camera's player target in start and in update