### PR TITLE
Richie week6

### DIFF
--- a/Board Game Editor/Assets/Resources/Scenes/MainMenu.unity
+++ b/Board Game Editor/Assets/Resources/Scenes/MainMenu.unity
@@ -276,7 +276,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &77280733
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -398,7 +398,7 @@ Transform:
   - {fileID: 1343161103}
   - {fileID: 77280736}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &201030716
 MonoBehaviour:
@@ -760,6 +760,7 @@ MonoBehaviour:
   - {fileID: 2100000, guid: 5a95ec3a21490c9d68704e0f2595c922, type: 2}
   - {fileID: 2100000, guid: c0a9875af924853acb61f0a1c5995ddb, type: 2}
   selectedPieceColors: []
+  defaultGamePiece: {fileID: 2100000, guid: adfe18202d336794684550be218ac021, type: 2}
 --- !u!1 &322665075
 GameObject:
   m_ObjectHideFlags: 0
@@ -796,9 +797,9 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 20}
+  m_SizeDelta: {x: -17, y: 20}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &322665077
 MonoBehaviour:
@@ -1511,9 +1512,9 @@ RectTransform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 20}
+  m_SizeDelta: {x: -17, y: 20}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &679308857
 MonoBehaviour:
@@ -2069,9 +2070,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -17, y: -17}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &770884775
 MonoBehaviour:
@@ -2485,7 +2486,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1000007689
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2613,9 +2614,9 @@ RectTransform:
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 0}
+  m_SizeDelta: {x: 20, y: -17}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1055038745
 MonoBehaviour:
@@ -2737,8 +2738,8 @@ RectTransform:
   m_Father: {fileID: 800981395}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.59749997}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -2944,7 +2945,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1077326794
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3305,7 +3306,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -3347,6 +3348,124 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1157691487}
   m_CullTransparentMesh: 1
+--- !u!1 &1281517090
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1281517094}
+  - component: {fileID: 1281517091}
+  - component: {fileID: 1281517093}
+  - component: {fileID: 1281517092}
+  m_Layer: 0
+  m_Name: PlayerSelectCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &1281517091
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1281517090}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 32
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &1281517092
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1281517090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!81 &1281517093
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1281517090}
+  m_Enabled: 0
+--- !u!4 &1281517094
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1281517090}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.64, y: 1.08, z: 0}
+  m_LocalScale: {x: 0.00925926, y: 0.00925926, z: 0.00925926}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1307122936
 GameObject:
   m_ObjectHideFlags: 0
@@ -3609,9 +3728,9 @@ Canvas:
   m_GameObject: {fileID: 1343161099}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
+  m_RenderMode: 1
+  m_Camera: {fileID: 1281517091}
+  m_PlaneDistance: 10
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
   m_OverrideSorting: 0
@@ -3799,7 +3918,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1397732245
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4567,9 +4686,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -17, y: -17}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1562340653
 MonoBehaviour:
@@ -4663,9 +4782,9 @@ RectTransform:
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 0}
+  m_SizeDelta: {x: 20, y: -17}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1593871577
 MonoBehaviour:
@@ -4776,7 +4895,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1355578065289800390, guid: 0079d14faf2fd36ab95ea0401b862450, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1355578065289800390, guid: 0079d14faf2fd36ab95ea0401b862450, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5465,8 +5584,8 @@ RectTransform:
   m_Father: {fileID: 630133128}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.59749997}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -5901,7 +6020,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -6800,6 +6919,10 @@ PrefabInstance:
     - target: {fileID: 634230865182010028, guid: 66f34b6654a5a35058f15689cd5c0166, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1742190385657042092, guid: 66f34b6654a5a35058f15689cd5c0166, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2486640577380297569, guid: 66f34b6654a5a35058f15689cd5c0166, type: 3}
       propertyPath: m_Name

--- a/Board Game Editor/Assets/Resources/Scripts/CameraController.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/CameraController.cs
@@ -50,7 +50,8 @@ public class CameraController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if(!GetComponent<GameManager>().gameOver){
+        if (!GetComponent<GameManager>().gameOver)
+        {
             if (Input.GetKeyDown(KeyCode.Escape))
             {
                 TogglePauseGame();
@@ -67,7 +68,7 @@ public class CameraController : MonoBehaviour
             }
         }
 
-        if(GetComponent<GameManager>().gameOver)
+        if (GetComponent<GameManager>().gameOver)
         {
             playerTarget = GameObject.FindGameObjectWithTag("GameOverCam").transform;
             followTransform.eulerAngles = new Vector3(38, 0, 0);
@@ -97,6 +98,7 @@ public class CameraController : MonoBehaviour
 
     public void ReturnToMainMenu()
     {
+        Time.timeScale = 1f;
         SceneController sceneCtrl = GameObject.FindGameObjectWithTag("SceneController").GetComponent<SceneController>();
         sceneCtrl.GoToMainMenu();
     }

--- a/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
@@ -105,17 +105,10 @@ public class PlayerSelect : MonoBehaviour
 
     public void InitColorToPiece(GameObject piece)
     {
-        // Image image = piece.GetComponentInChildren<Image>();
         MeshRenderer mesh = piece.GetComponentInChildren<MeshRenderer>();
 
-        // image.material = availablePieceColors.Last.Value;
-        // image.color = image.material.color;
-
-        // if (image.color == image.defaultMaterial.color)
         if (mesh.sharedMaterial == defaultGamePiece)
         {
-            // Debug.Log(availablePieceColors.Last.Value);
-            // image.color = availablePieceColors.Last.Value.color;
             mesh.sharedMaterial = availablePieceColors.Last.Value;
 
             selectedPieceColors[pieceSelectors.IndexOf(piece)] = availablePieceColors.Last.Value;
@@ -125,16 +118,12 @@ public class PlayerSelect : MonoBehaviour
 
     public void RemoveColorFromPiece(GameObject piece)
     {
-        // Image image = piece.GetComponentInChildren<Image>();
         MeshRenderer mesh = piece.GetComponentInChildren<MeshRenderer>();
 
-        // if (image.color != image.defaultMaterial.color)
         if (mesh.sharedMaterial != defaultGamePiece)
         {
-            // availablePieceColors.AddLast(colorMapping[image.color]);
             availablePieceColors.AddLast(mesh.sharedMaterial);
             selectedPieceColors[pieceSelectors.IndexOf(piece)] = defaultGamePiece;//colorMapping[image.color];
-            // image.color = image.defaultMaterial.color;
             mesh.sharedMaterial = defaultGamePiece;
 
         }
@@ -184,7 +173,6 @@ public class PlayerSelect : MonoBehaviour
                 break;
         }
 
-        // pieceSelector.GetComponentInChildren<Image>().color = nextMaterial.color;
         pieceSelector.GetComponentInChildren<MeshRenderer>().sharedMaterial = nextMaterial;
         selectedPieceColors[pieceSelectors.IndexOf(pieceSelector)] = nextMaterial;
 

--- a/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
@@ -104,14 +104,17 @@ public class PlayerSelect : MonoBehaviour
     public void InitColorToPiece(GameObject piece)
     {
         Image image = piece.GetComponentInChildren<Image>();
+        MeshRenderer mesh = piece.GetComponentInChildren<MeshRenderer>();
 
         // image.material = availablePieceColors.Last.Value;
         // image.color = image.material.color;
 
         if (image.color == image.defaultMaterial.color)
         {
-            Debug.Log(availablePieceColors.Last.Value);
+            // Debug.Log(availablePieceColors.Last.Value);
             image.color = availablePieceColors.Last.Value.color;
+            mesh.material = availablePieceColors.Last.Value;
+
             selectedPieceColors[pieceSelectors.IndexOf(piece)] = availablePieceColors.Last.Value;
             availablePieceColors.RemoveLast();
         }
@@ -120,12 +123,15 @@ public class PlayerSelect : MonoBehaviour
     public void RemoveColorFromPiece(GameObject piece)
     {
         Image image = piece.GetComponentInChildren<Image>();
+        MeshRenderer mesh = piece.GetComponentInChildren<MeshRenderer>();
 
         if (image.color != image.defaultMaterial.color)
         {
             availablePieceColors.AddLast(colorMapping[image.color]);
             selectedPieceColors[pieceSelectors.IndexOf(piece)] = colorMapping[image.color];
             image.color = image.defaultMaterial.color;
+            mesh.material = image.defaultMaterial;
+
         }
 
     }
@@ -174,6 +180,7 @@ public class PlayerSelect : MonoBehaviour
         }
 
         pieceSelector.GetComponentInChildren<Image>().color = nextMaterial.color;
+        pieceSelector.GetComponentInChildren<MeshRenderer>().material = nextMaterial;
         selectedPieceColors[pieceSelectors.IndexOf(pieceSelector)] = nextMaterial;
 
     }

--- a/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
+++ b/Board Game Editor/Assets/Resources/Scripts/UI/PlayerSelect.cs
@@ -23,6 +23,8 @@ public class PlayerSelect : MonoBehaviour
 
     public Dictionary<Color, Material> colorMapping;
 
+    public Material defaultGamePiece;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -103,17 +105,18 @@ public class PlayerSelect : MonoBehaviour
 
     public void InitColorToPiece(GameObject piece)
     {
-        Image image = piece.GetComponentInChildren<Image>();
+        // Image image = piece.GetComponentInChildren<Image>();
         MeshRenderer mesh = piece.GetComponentInChildren<MeshRenderer>();
 
         // image.material = availablePieceColors.Last.Value;
         // image.color = image.material.color;
 
-        if (image.color == image.defaultMaterial.color)
+        // if (image.color == image.defaultMaterial.color)
+        if (mesh.sharedMaterial == defaultGamePiece)
         {
             // Debug.Log(availablePieceColors.Last.Value);
-            image.color = availablePieceColors.Last.Value.color;
-            mesh.material = availablePieceColors.Last.Value;
+            // image.color = availablePieceColors.Last.Value.color;
+            mesh.sharedMaterial = availablePieceColors.Last.Value;
 
             selectedPieceColors[pieceSelectors.IndexOf(piece)] = availablePieceColors.Last.Value;
             availablePieceColors.RemoveLast();
@@ -122,15 +125,17 @@ public class PlayerSelect : MonoBehaviour
 
     public void RemoveColorFromPiece(GameObject piece)
     {
-        Image image = piece.GetComponentInChildren<Image>();
+        // Image image = piece.GetComponentInChildren<Image>();
         MeshRenderer mesh = piece.GetComponentInChildren<MeshRenderer>();
 
-        if (image.color != image.defaultMaterial.color)
+        // if (image.color != image.defaultMaterial.color)
+        if (mesh.sharedMaterial != defaultGamePiece)
         {
-            availablePieceColors.AddLast(colorMapping[image.color]);
-            selectedPieceColors[pieceSelectors.IndexOf(piece)] = colorMapping[image.color];
-            image.color = image.defaultMaterial.color;
-            mesh.material = image.defaultMaterial;
+            // availablePieceColors.AddLast(colorMapping[image.color]);
+            availablePieceColors.AddLast(mesh.sharedMaterial);
+            selectedPieceColors[pieceSelectors.IndexOf(piece)] = defaultGamePiece;//colorMapping[image.color];
+            // image.color = image.defaultMaterial.color;
+            mesh.sharedMaterial = defaultGamePiece;
 
         }
 
@@ -162,7 +167,7 @@ public class PlayerSelect : MonoBehaviour
     public void ChangeColor(GameObject pieceSelector, DIRECTION direction)
     {
         Material nextMaterial = availablePieceColors.Last.Value;
-        Material currentMaterial = colorMapping[pieceSelector.GetComponentInChildren<Image>().color];
+        Material currentMaterial = pieceSelector.GetComponentInChildren<MeshRenderer>().sharedMaterial; //colorMapping[pieceSelector.GetComponentInChildren<Image>().color];
 
         switch (direction)
         {
@@ -179,8 +184,8 @@ public class PlayerSelect : MonoBehaviour
                 break;
         }
 
-        pieceSelector.GetComponentInChildren<Image>().color = nextMaterial.color;
-        pieceSelector.GetComponentInChildren<MeshRenderer>().material = nextMaterial;
+        // pieceSelector.GetComponentInChildren<Image>().color = nextMaterial.color;
+        pieceSelector.GetComponentInChildren<MeshRenderer>().sharedMaterial = nextMaterial;
         selectedPieceColors[pieceSelectors.IndexOf(pieceSelector)] = nextMaterial;
 
     }

--- a/Board Game Editor/Assets/Resources/UI/SelectPlayer.prefab
+++ b/Board Game Editor/Assets/Resources/UI/SelectPlayer.prefab
@@ -781,6 +781,14 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 6153298779359016118, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6153298779359016118, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: adfe18202d336794684550be218ac021, type: 2}
     - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
       propertyPath: m_RootOrder
       value: 1

--- a/Board Game Editor/Assets/Resources/UI/SelectPlayer.prefab
+++ b/Board Game Editor/Assets/Resources/UI/SelectPlayer.prefab
@@ -168,7 +168,7 @@ RectTransform:
   m_Children:
   - {fileID: 3298884697636527650}
   m_Father: {fileID: 634230865182010028}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -556,6 +556,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8257713429855770665}
+  - {fileID: 2003171481835800648}
   - {fileID: 7280761119002895831}
   - {fileID: 1328095542855682443}
   - {fileID: 8381431913419729510}
@@ -600,7 +601,7 @@ RectTransform:
   m_Children:
   - {fileID: 8744775169656837165}
   m_Father: {fileID: 634230865182010028}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -706,7 +707,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7280761119002895831
 RectTransform:
   m_ObjectHideFlags: 0
@@ -720,7 +721,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 634230865182010028}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -765,3 +766,85 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &5569097105831206938
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 634230865182010028}
+    m_Modifications:
+    - target: {fileID: 5809849668248652258, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_Name
+      value: GamePiece
+      objectReference: {fileID: 0}
+    - target: {fileID: 5809849668248652258, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -80
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6511915917702346349, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+--- !u!4 &2003171481835800648 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6234628500917954642, guid: 546fc7f601ae3fb44ba9b07e8ec4a244, type: 3}
+  m_PrefabInstance: {fileID: 5569097105831206938}
+  m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
Replaced images on player select screen with 3d models of the game pieces. Refactored the code to apply color selection to the 3d models and save that data instead of reading from the images. Removed image references from the code.

Note for future: applying a material to a mesh creates an instance of that material, which does not compare equal in comparison checks. after much searching, you must use sharedMaterial property instead of material property whenever reading from, comparing, or setting the value of a material. 

Ideally, we get the pieces to rotate so that when the model is an astronaut it will be a nice effect. Right now they are static.